### PR TITLE
use a __version__ variable, update setup.py to use it

### DIFF
--- a/macchiato.py
+++ b/macchiato.py
@@ -5,6 +5,9 @@ import tempfile
 import black
 
 
+__version__ = "1.1.0"
+
+
 def macchiato(in_fp, out_fp, args=None):
     if args is None:
         args = []

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import re, ast
 CURRENT_DIR = Path(__file__).parent
 
 
+# This function is borrowed from the setup.py at https://github.com/psf/black
 def get_version() -> str:
     macchiato_py = CURRENT_DIR / "macchiato.py"
     _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,18 @@
 from setuptools import setup
+from pathlib import Path
+import re, ast
+
+
+CURRENT_DIR = Path(__file__).parent
+
+
+def get_version() -> str:
+    macchiato_py = CURRENT_DIR / "macchiato.py"
+    _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
+    with open(macchiato_py, "r", encoding="utf8") as f:
+        match = _version_re.search(f.read())
+        version = match.group("version") if match is not None else '"unknown"'
+    return str(ast.literal_eval(version))
 
 setup(
     name="black-macchiato",
@@ -7,7 +21,7 @@ setup(
     author="wouter bolsterlee",
     author_email="wouter@bolsterl.ee",
     license="BSD License",
-    version="1.1.0",
+    version=get_version(),
     py_modules=["macchiato"],
     install_requires=["black"],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup
+import ast
 from pathlib import Path
-import re, ast
+import re
+from setuptools import setup
 
 
 CURRENT_DIR = Path(__file__).parent


### PR DESCRIPTION
This borrows/utilizes some code from [black](https://github.com/psf/black) to allow macchiato to define a `__version__` variable in `macchiato.py` and use that to set the version number in `setup.py`. This also allows the user to programmatically obtain the version of `macchiato`, which is currently not possible to do, from either the Python API or the command line.