### PR TITLE
use the config file from cwd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Example::
 
 Integrating this piping of input and output with your editor is left
 as an exercise to the reader. For instance, Vim users can use visual
-line mode and type ``:!black-macchiato``, and Emacs users can use
+line mode and type ``:!cd %:p:h && black-macchiato``, and Emacs users can use
 `python-black.el`__.
 
 __ https://github.com/wbolster/emacs-python-black

--- a/macchiato.py
+++ b/macchiato.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import sys
 import tempfile
 
@@ -50,9 +51,16 @@ def macchiato(in_fp, out_fp, args=None):
         fp.flush()
 
         # Run black.
+        if "--config" not in args:
+            root = black.find_project_root((os.getcwd(),))
+            path = root / "pyproject.toml"
+            if path.is_file():
+                args.append("--config")
+                args.append(str(path))
         if "--quiet" not in args:
             args.append("--quiet")
         args.append(fp.name)
+
         try:
             exit_code = black.main(args=args)
         except SystemExit as exc:


### PR DESCRIPTION
As we use a temporary file to format the snippet, `black` cannot find
the config to use.