### PR TITLE
Handle else/elif/except/finally and indented functions better

### DIFF
--- a/macchiato.py
+++ b/macchiato.py
@@ -81,9 +81,12 @@ def macchiato(in_fp, out_fp, args=None):
             # Write output.
             fp.seek(0)
             formatted_lines = fp.readlines()
-            out_fp.write("\n" * n_blank_before)
             until = len(formatted_lines) - n_fake_after
-            for line in formatted_lines[n_fake_before:until]:
+            formatted_lines = formatted_lines[n_fake_before:until]
+            fmt_n_blank_before, _ = count_surrounding_blank_lines(formatted_lines)
+            formatted_lines = formatted_lines[fmt_n_blank_before:]
+            out_fp.write("\n" * n_blank_before)
+            for line in formatted_lines:
                 out_fp.write(line)
             out_fp.write("\n" * n_blank_after)
 

--- a/test_macchiato.py
+++ b/test_macchiato.py
@@ -31,6 +31,7 @@ def test_count_surrounding_blank_lines(lines, before, after):
         ("elif x==5:\n", "elif x == 5:\n"),
         ("'''\n'''\n", '"""\n"""\n'),  # tokenize error handling
         ("    finally :\n", "    finally:\n"),
+        ("    def f():\n        pass\n", "    def f():\n        pass\n"),
     ],
 )
 def test_macchiato(input, expected):

--- a/test_macchiato.py
+++ b/test_macchiato.py
@@ -27,7 +27,10 @@ def test_count_surrounding_blank_lines(lines, before, after):
         ("foo\n", "foo\n"),
         ("    foo\n", "    foo\n"),
         ("    if True:\n", "    if True:\n"),
-        ("\n\n        x=3\n\n", "\n\n        x = 3\n\n")
+        ("\n\n        x=3\n\n", "\n\n        x = 3\n\n"),
+        ("elif x==5:\n", "elif x == 5:\n"),
+        ("'''\n'''\n", '"""\n"""\n'),  # tokenize error handling
+        ("    finally :\n", "    finally:\n"),
     ],
 )
 def test_macchiato(input, expected):


### PR DESCRIPTION
This makes it possible to reformat lines that need to come after a block, like `elif` statements, and stops spurious whitespace from being added before indented functions.

I think those are the only problems I ran into in months of heavy use. Thank you for a very useful tool.