### PR TITLE
Refactor so that wrapping functionality can be reused more easily

### DIFF
--- a/macchiato.py
+++ b/macchiato.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import sys
 import tempfile
 import tokenize
@@ -97,10 +98,11 @@ def format_lines(lines: List[str], black_args=None) -> List[str]:
     if black_args is None:
         black_args = []
 
-    with tempfile.NamedTemporaryFile(suffix=".py", mode="wt+", delete=False) as fp:
+    with tempfile.NamedTemporaryFile(
+        suffix=".py", dir=os.getcwd(), mode="wt+", delete=True
+    ) as fp:
         # Copy the input.
-        for line in lines:
-            fp.write(line)
+        fp.writelines(lines)
         fp.flush()
 
         # Run black.

--- a/macchiato.py
+++ b/macchiato.py
@@ -9,7 +9,7 @@ import black
 
 __version__ = "1.2.0"
 
-_single_indent = " " * 4
+SINGLE_INDENT = " " * 4
 
 
 class WrapInfo(NamedTuple):
@@ -39,7 +39,7 @@ def _fake_before_lines(first_line: str) -> List[str]:
 
     # Handle regular indent
     for i in range(indent_levels):
-        prefix = _single_indent * i
+        prefix = SINGLE_INDENT * i
         fake_lines.append(f"{prefix}if True:\n")
 
     # Handle else/elif/except/finally
@@ -51,13 +51,13 @@ def _fake_before_lines(first_line: str) -> List[str]:
         first_token = None
     if first_token and first_token.type == tokenize.NAME:
         name = first_token.string
-        prefix = _single_indent * indent_levels
+        prefix = SINGLE_INDENT * indent_levels
         if name in {"else", "elif"}:
             fake_lines.append(f"{prefix}if True:\n")
-            fake_lines.append(f"{prefix}{_single_indent}pass\n")
+            fake_lines.append(f"{prefix}{SINGLE_INDENT}pass\n")
         elif name in {"except", "finally"}:
             fake_lines.append(f"{prefix}try:\n")
-            fake_lines.append(f"{prefix}{_single_indent}pass\n")
+            fake_lines.append(f"{prefix}{SINGLE_INDENT}pass\n")
 
     return fake_lines
 

--- a/macchiato.py
+++ b/macchiato.py
@@ -2,102 +2,180 @@ import itertools
 import sys
 import tempfile
 import tokenize
+from typing import IO, Iterable, List, NamedTuple, Optional, Tuple, cast
 
 import black
 
 
 __version__ = "1.2.0"
 
+_single_indent = " " * 4
 
-def macchiato(in_fp, out_fp, args=None):
-    if args is None:
-        args = []
 
-    # Read input.
-    lines = in_fp.readlines()
+class WrapInfo(NamedTuple):
+    """Describes the changes made when wrapping text."""
 
-    # Detect blank lines and deal with completely blank input.
-    n_blank_before, n_blank_after = count_surrounding_blank_lines(lines)
-    until = len(lines) - n_blank_after
-    lines = lines[n_blank_before:until]
-    if not lines:
-        out_fp.write("\n" * n_blank_before)
-        return 0
+    n_blank_before: int = 0
+    n_blank_after: int = 0
+    n_fake_before: int = 0
+    n_fake_after: int = 0
 
-    # Detect indentation. Add "if True:" lines if needed for valid syntax.
-    first_line = lines[0]
-    indent = len(first_line) - len(first_line.lstrip())
-    n_fake_before, remainder = divmod(indent, 4)
+
+def _indent_levels(line: str) -> int:
+    """Determine how many levels the line is indented."""
+
+    spaces = len(line) - len(line.lstrip())
+    levels, remainder = divmod(spaces, 4)
     if remainder:
         raise ValueError("indent of first line must be a multiple of four")
-    for i in range(n_fake_before):
-        prefix = 4 * i * " "
-        lines.insert(i, f"{prefix}if True:\n")
+    return levels
+
+
+def _fake_before_lines(first_line: str) -> List[str]:
+    """Construct the fake lines that should go before the text."""
+
+    fake_lines = []
+    indent_levels = _indent_levels(first_line)
+
+    # Handle regular indent
+    for i in range(indent_levels):
+        prefix = _single_indent * i
+        fake_lines.append(f"{prefix}if True:\n")
 
     # Handle else/elif/except/finally
     try:
-        first_token = next(
+        first_token: Optional[tokenize.TokenInfo] = next(
             tokenize.generate_tokens(iter([first_line.lstrip()]).__next__)
         )
     except tokenize.TokenError:
         first_token = None
     if first_token and first_token.type == tokenize.NAME:
         name = first_token.string
+        prefix = _single_indent * indent_levels
         if name in {"else", "elif"}:
-            lines.insert(n_fake_before, f"{indent * ' '}if True:\n")
-            lines.insert(n_fake_before + 1, f"{indent * ' '}    pass\n")
-            n_fake_before += 2
+            fake_lines.append(f"{prefix}if True:\n")
+            fake_lines.append(f"{prefix}{_single_indent}pass\n")
         elif name in {"except", "finally"}:
-            lines.insert(n_fake_before, f"{indent * ' '}try:\n")
-            lines.insert(n_fake_before + 1, f"{indent * ' '}    pass\n")
-            n_fake_before += 2
+            fake_lines.append(f"{prefix}try:\n")
+            fake_lines.append(f"{prefix}{_single_indent}pass\n")
 
-    # Detect an unclosed block at the end. Add ‘pass’ at the end of the line if
-    # needed for valid syntax.
-    last_line = lines[-1]
-    n_fake_after = 0
+    return fake_lines
+
+
+def _fake_after_lines(last_line: str) -> List[str]:
+    """Construct the fake lines that should go after the text."""
+
+    lines = []
+
+    # Detect an unclosed block at the end. Add a ‘pass’ line if needed for valid syntax.
     if last_line.rstrip().endswith(":"):
-        lines[-1] = last_line.rstrip() + "pass\n"
-        n_fake_after = 1
+        indent_levels = _indent_levels(last_line)
+        prefix = _single_indent * (indent_levels + 1)
+        lines.append(f"{prefix}pass\n")
+
+    return lines
+
+
+def wrap_lines(lines: List[str]) -> Tuple[List[str], WrapInfo]:
+    """Wrap the input lines with fake text, to fake a complete source document."""
+
+    # Strip leading and trailing blank lines.
+    n_blank_before, n_blank_after = count_surrounding_blank_lines(lines)
+    until = len(lines) - n_blank_after
+    lines = lines[n_blank_before:until]
+    if not lines:
+        wrap_info = WrapInfo(n_blank_before=n_blank_before, n_blank_after=n_blank_after)
+        return lines, wrap_info
+
+    # Construct fake lines that need to surround the text for valid syntax.
+    first_line = lines[0]
+    fake_before_lines = _fake_before_lines(first_line)
+
+    last_line = lines[-1]
+    fake_after_lines = _fake_after_lines(last_line)
+
+    lines = fake_before_lines + lines + fake_after_lines
+
+    wrap_info = WrapInfo(
+        n_blank_before=n_blank_before,
+        n_blank_after=n_blank_after,
+        n_fake_before=len(fake_before_lines),
+        n_fake_after=len(fake_after_lines),
+    )
+    return lines, wrap_info
+
+
+def format_lines(lines: List[str], black_args=None) -> List[str]:
+    if black_args is None:
+        black_args = []
 
     with tempfile.NamedTemporaryFile(suffix=".py", mode="wt+", delete=False) as fp:
-
         # Copy the input.
         for line in lines:
             fp.write(line)
-
         fp.flush()
 
         # Run black.
-        if "--quiet" not in args:
-            args.append("--quiet")
-        args.append(fp.name)
+        if "--quiet" not in black_args:
+            black_args.append("--quiet")
+        black_args.append(fp.name)
+
         try:
-            exit_code = black.main(args=args)
+            exit_code = black.main(args=black_args)
         except SystemExit as exc:
             exit_code = exc.code
 
         if exit_code == 0:
             # Write output.
             fp.seek(0)
-            formatted_lines = fp.readlines()
-            until = len(formatted_lines) - n_fake_after
-            formatted_lines = formatted_lines[n_fake_before:until]
-            fmt_n_blank_before, _ = count_surrounding_blank_lines(formatted_lines)
-            formatted_lines = formatted_lines[fmt_n_blank_before:]
-            out_fp.write("\n" * n_blank_before)
-            for line in formatted_lines:
-                out_fp.write(line)
-            out_fp.write("\n" * n_blank_after)
+            return cast(List[str], fp.readlines())
 
-    return exit_code
+        raise RuntimeError("black failed", exit_code)
+
+
+def unwrap_lines(lines: List[str], wrap_info: WrapInfo) -> List[str]:
+    """Unwrap previously-wrapped text."""
+
+    until = len(lines) - wrap_info.n_fake_after
+    lines = lines[wrap_info.n_fake_before : until]
+
+    fmt_n_blank_before, _ = count_surrounding_blank_lines(lines)
+    lines = lines[fmt_n_blank_before:]
+
+    # Restore blank lines.
+    blank_before = ["\n"] * wrap_info.n_blank_before
+    blank_after = ["\n"] * wrap_info.n_blank_after
+
+    return blank_before + lines + blank_after
+
+
+def macchiato(in_fp: IO[str], out_fp: IO[str], args=None):
+    # Read input.
+    lines = in_fp.readlines()
+
+    # Build syntactically valid text.
+    lines, wrap_info = wrap_lines(lines)
+
+    # Format.
+    try:
+        lines = format_lines(lines, black_args=args)
+    except RuntimeError as e:
+        exit_code = e.args[1]
+        return exit_code
+
+    # Unwrap text and write output.
+    lines = unwrap_lines(lines, wrap_info)
+    for line in lines:
+        out_fp.write(line)
+
+    return 0
 
 
 def is_blank_string(s):
     return s.isspace() or not s
 
 
-def count_surrounding_blank_lines(lines):
+def count_surrounding_blank_lines(lines: Iterable[str]) -> Tuple[int, int]:
     before = 0
     after = 0
     grouper = itertools.groupby(lines, is_blank_string)

--- a/test_macchiato.py
+++ b/test_macchiato.py
@@ -32,6 +32,7 @@ def test_count_surrounding_blank_lines(lines, before, after):
         ("'''\n'''\n", '"""\n"""\n'),  # tokenize error handling
         ("    finally :\n", "    finally:\n"),
         ("    def f():\n        pass\n", "    def f():\n        pass\n"),
+        ("    def f(a,\n          b):\n", "    def f(a, b):\n"),
     ],
 )
 def test_macchiato(input, expected):

--- a/test_macchiato.py
+++ b/test_macchiato.py
@@ -1,4 +1,7 @@
 import io
+import os
+import pathlib
+from typing import Generator
 
 import macchiato
 
@@ -42,3 +45,43 @@ def test_macchiato(input, expected):
     assert exit_code == 0
     output = out_fp.getvalue()
     assert output == expected
+
+
+class TestConfig:
+    @pytest.fixture
+    def working_dir(
+        self, tmp_path: pathlib.Path
+    ) -> Generator[pathlib.Path, None, None]:
+        """Provide a temporary, current working directory."""
+
+        orig_cwd = os.getcwd()
+
+        working_dir = tmp_path / "project" / "component"
+        working_dir.mkdir(parents=True)
+        os.chdir(working_dir)
+        yield working_dir
+
+        os.chdir(orig_cwd)
+
+    def test_detection(self, working_dir: pathlib.Path):
+        """Make sure that black config is used if it is present."""
+
+        orig = '["abcdefghijklm", "nopqrstuvwxyz"]\n'
+
+        def do_format() -> str:
+            in_fp = io.StringIO(orig)
+            out_fp = io.StringIO()
+            assert macchiato.macchiato(in_fp, out_fp) == 0
+            return out_fp.getvalue()
+
+        # No config, defaults should be used.
+        assert do_format() == orig
+
+        # Add config file to parent directory. Shorter line length setting should be used.
+        with (working_dir.parent / "pyproject.toml").open("w") as fp:
+            fp.write("[tool.black]\nline_length = 25\n")
+        assert do_format() == """[\n    "abcdefghijklm",\n    "nopqrstuvwxyz",\n]\n"""
+
+        # Fake a .git directory in current directory. Config file should be ignored.
+        (working_dir / ".git").mkdir()
+        assert do_format() == orig


### PR DESCRIPTION
I wanted to incorporate black-macchiato into a plugin, so I refactored the `macchiato` function to expose the wrapping functionality. I'm not sure if this is the sort of change you'd want to merge, but in case it looks worthwhile, here it is :slightly_smiling_face: 