### PR TITLE
fix empty multi-line string test

### DIFF
--- a/test_macchiato.py
+++ b/test_macchiato.py
@@ -32,7 +32,7 @@ def test_count_surrounding_blank_lines(lines, before, after):
         ("    if True:\n", "    if True:\n"),
         ("\n\n        x=3\n\n", "\n\n        x = 3\n\n"),
         ("elif x==5:\n", "elif x == 5:\n"),
-        ("'''\n'''\n", '"""\n"""\n'),  # tokenize error handling
+        ("'''\n'''\n", '""" """\n'),  # tokenize error handling
         ("    finally :\n", "    finally:\n"),
         ("    def f():\n        pass\n", "    def f():\n        pass\n"),
         ("    def f(a,\n          b):\n", "    def f(a, b):\n"),


### PR DESCRIPTION
Black changed formatting of empty multi-line strings in PR 4095[1], which appeared in release 24.1.0.

Since such a string appears in the test cases, the tests fail with recent black versions. This commit makes the test pass again.

[1]: https://github.com/psf/black/pull/4095